### PR TITLE
Fix theme download and update repository structure

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -4,6 +4,11 @@
       "version": "1.1.0",
       "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
       "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/markheydon/devcontainer-features/copilot-likes:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/markheydon/devcontainer-features/copilot-likes@sha256:00707d0886649a89871d031af818e13962b46787a2dc62507d4036edf6d114a7",
+      "integrity": "sha256:00707d0886649a89871d031af818e13962b46787a2dc62507d4036edf6d114a7"
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "remoteUser": "vscode",
     "features": {
         "ghcr.io/devcontainers/features/github-cli:1": {},
-		"ghcr.io/markheydon/devcontainer-features/copilot-likes:1": {}
+        "ghcr.io/markheydon/devcontainer-features/copilot-likes:1": {}
     },
     "portsAttributes": {
         "80": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,8 @@
     "shutdownAction": "stopCompose",
     "remoteUser": "vscode",
     "features": {
-        "ghcr.io/devcontainers/features/github-cli:1": {}
+        "ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/markheydon/devcontainer-features/copilot-likes:1": {}
     },
     "portsAttributes": {
         "80": {

--- a/.github/prompts/theme-rebrand.prompt.md
+++ b/.github/prompts/theme-rebrand.prompt.md
@@ -32,6 +32,11 @@ Collect and confirm these values before editing:
 - `prefix_new` (optional; only if prefix rebrand requested)
 - `security_contact_url` (optional; only if known)
 
+## Repository naming requirement
+
+- For default Theme Distribution slug behavior, repositories created from this template should end in `-dev`.
+- If the repository does not end in `-dev`, require an explicit `THEME_SLUG` (or manual `theme_slug`) in distribution configuration.
+
 If any required value is missing, ask for it and stop edits until provided.
 
 ## Step 1 - Present change plan first

--- a/.github/workflows/theme-distribution.yml
+++ b/.github/workflows/theme-distribution.yml
@@ -115,6 +115,8 @@ jobs:
     needs: resolve-config
     if: ${{ needs.resolve-config.outputs.create_zip == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout source repo
         uses: actions/checkout@v6
@@ -166,11 +168,23 @@ jobs:
           zip -r "$GITHUB_WORKSPACE/dist/$ZIP_NAME" "$THEME_SLUG"
 
       - name: Upload ZIP artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: theme-package
           path: dist/${{ needs.resolve-config.outputs.zip_name }}
           if-no-files-found: error
+          archive: false
+
+      - name: Upload ZIP as release asset
+        if: ${{ github.event_name == 'release' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          ZIP_NAME: ${{ needs.resolve-config.outputs.zip_name }}
+          SOURCE_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh release upload "$RELEASE_TAG" "dist/$ZIP_NAME" --repo "$SOURCE_REPOSITORY" --clobber
 
   sync-theme-repo:
     name: Sync theme files to destination repo

--- a/.github/workflows/theme-distribution.yml
+++ b/.github/workflows/theme-distribution.yml
@@ -11,7 +11,7 @@ on:
         required: false
         default: ''
       theme_slug:
-        description: 'Optional WordPress theme directory name (defaults to repository name without trailing -src)'
+        description: 'Optional WordPress theme directory name (defaults to repository name without trailing -dev)'
         required: false
         default: ''
       create_zip:
@@ -60,7 +60,12 @@ jobs:
           destination_repo="${INPUT_DESTINATION_REPO:-$VAR_DESTINATION_REPO}"
           theme_slug="${INPUT_THEME_SLUG:-$VAR_THEME_SLUG}"
           if [[ -z "$theme_slug" ]]; then
-            theme_slug="${REPO_NAME%-src}"
+            if [[ "$REPO_NAME" != *-dev ]]; then
+              echo "theme_slug was not provided and repository name ($REPO_NAME) does not end with -dev."
+              echo "Rename the repository with a -dev suffix or set THEME_SLUG/theme_slug explicitly."
+              exit 1
+            fi
+            theme_slug="${REPO_NAME%-dev}"
           fi
 
           if [[ ! "$theme_slug" =~ ^[A-Za-z0-9._-]+$ ]] || [[ "$theme_slug" == "." ]] || [[ "$theme_slug" == ".." ]]; then

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Avada Child Theme Source Files
+# Avada Child Theme Development Repository
 
 ## Overview
 
@@ -16,7 +16,7 @@ This repo is focused on local development environment (dev container, coding sta
 
 ## Quick Start
 
-1. Create a new repository from this template.
+1. Create a new repository from this template. For default Theme Distribution behavior, name it with a trailing `-dev` suffix.
 2. Open the repository in VS Code.
 3. Reopen in Dev Container.
 4. Wait for container startup tasks to finish (including automatic WordPress setup via `.devcontainer/setup.sh`).
@@ -155,7 +155,7 @@ This template includes `.github/workflows/theme-distribution.yml` to automate de
 ### Supported modes
 
 - **ZIP package mode**: creates a clean ZIP containing only the theme files from `src/`.
-- **Repo sync mode**: optionally syncs only `src/` contents to a destination repo (for example a non-`-src` repo).
+- **Repo sync mode**: optionally syncs only `src/` contents to a destination repo (for example a non-`-dev` repo).
 
 On each published release, ZIP generation is enabled by default. Repo sync runs when a destination repo is configured.
 
@@ -171,7 +171,7 @@ ZIP package structure is WordPress-ready: the ZIP contains one top-level folder 
 Set these in repository **Variables** (Settings → Secrets and variables → Actions → Variables):
 
 - `THEME_DESTINATION_REPO` (optional): destination in `owner/repo` format.
-- `THEME_SLUG` (optional): theme folder name in the ZIP. Default is repo name without trailing `-src`.
+- `THEME_SLUG` (optional): theme folder name in the ZIP. Default is repo name without trailing `-dev`.
 - `THEME_CREATE_ZIP` (optional): `true`/`false` for release-triggered ZIP creation (default `true`).
 - `THEME_SYNC_REPO` (optional): `true`/`false` for release-triggered repo sync (default `true`).
 
@@ -191,6 +191,11 @@ Use **Actions → Theme Distribution → Run workflow** to override defaults per
 Manual ZIP runs upload the generated installable theme ZIP as a single-file artifact for validation.
 
 Release-triggered ZIP runs also attach that same installable ZIP as a release asset for end-user downloads.
+
+### Repository naming requirement
+
+- Repositories created from this template should use a trailing `-dev` suffix when relying on default Theme Distribution slug behavior.
+- If your repository does not end in `-dev`, set `THEME_SLUG` (or `theme_slug` during manual runs) explicitly.
 
 ## Using This Template For A New Child Theme
 
@@ -217,7 +222,7 @@ Use this quick checklist first, then follow [RUNBOOK.md](RUNBOOK.md) for full de
 
 ### Distribution naming behavior
 
-- ZIP folder naming defaults to repository name with trailing `-src` removed.
+- ZIP folder naming defaults to repository name with trailing `-dev` removed.
 - Override with `THEME_SLUG` variable (or `theme_slug` in manual run input) when needed.
 - ZIP filename uses `theme-slug + release-tag` for release runs and `theme-slug + short-sha` for manual runs.
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ This template includes `.github/workflows/theme-distribution.yml` to automate de
 
 On each published release, ZIP generation is enabled by default. Repo sync runs when a destination repo is configured.
 
+ZIP package structure is WordPress-ready: the ZIP contains one top-level folder named by the theme slug, with the theme files inside that folder.
+
 ### Composer dependency behavior
 
 - For ZIP packages, if `src/composer.json` exists, the workflow runs `composer install --no-dev` in the staged theme directory so runtime dependencies are included in the ZIP.
@@ -185,6 +187,10 @@ Use **Actions → Theme Distribution → Run workflow** to override defaults per
 - `theme_slug`: optional override for ZIP theme folder name
 - `create_zip`: enable/disable ZIP output
 - `sync_repo`: enable/disable repo sync
+
+Manual ZIP runs upload the generated installable theme ZIP as a single-file artifact for validation.
+
+Release-triggered ZIP runs also attach that same installable ZIP as a release asset for end-user downloads.
 
 ## Using This Template For A New Child Theme
 
@@ -213,6 +219,7 @@ Use this quick checklist first, then follow [RUNBOOK.md](RUNBOOK.md) for full de
 
 - ZIP folder naming defaults to repository name with trailing `-src` removed.
 - Override with `THEME_SLUG` variable (or `theme_slug` in manual run input) when needed.
+- ZIP filename uses `theme-slug + release-tag` for release runs and `theme-slug + short-sha` for manual runs.
 
 ## Testing Theme Distribution (Quick Path)
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -19,7 +19,7 @@ Optional fast path: use the GitHub Copilot prompt [.github/prompts/theme-rebrand
 
 ### 1. Create your repository from this template
 
-1. Create a new repository from this template.
+1. Create a new repository from this template using a name that ends with `-dev` if you want default Theme Distribution slug behavior.
 2. Clone/open it in VS Code.
 3. Reopen in Dev Container and wait for setup to complete.
 
@@ -82,9 +82,11 @@ Distribution behavior is defined in [theme-distribution.yml](.github/workflows/t
 Set in repository settings under Actions Variables:
 
 - `THEME_DESTINATION_REPO` (optional): `owner/repo` destination for sync.
-- `THEME_SLUG` (optional): override theme folder slug for ZIP output.
+- `THEME_SLUG` (optional): override theme folder slug for ZIP output. When not set, the workflow defaults to repository name without trailing `-dev`.
 - `THEME_CREATE_ZIP` (optional): `true` or `false` default for release runs.
 - `THEME_SYNC_REPO` (optional): `true` or `false` default for release runs.
+
+If the repository name does not end with `-dev`, you must set `THEME_SLUG` (or provide `theme_slug` during manual runs) for distribution runs.
 
 ### 3. Configure Actions Secret for cross-repo sync
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -142,8 +142,9 @@ Test set 1: ZIP-only
 Expected result:
 
 - ZIP job runs.
-- Artifact named `theme-package` is uploaded.
-- ZIP contains only files staged from [src](src).
+- Artifact named `theme-package` is uploaded as a single file artifact.
+- Downloaded file is the installable theme ZIP (not a ZIP containing another ZIP).
+- Installable ZIP contains one top-level theme folder, and that folder contains only files staged from [src](src).
 
 Test set 2: Sync-only to disposable target
 
@@ -163,12 +164,14 @@ Publish a test release to validate release trigger behavior.
 Expected result:
 
 - ZIP suffix uses release tag.
+- Release includes the same installable theme ZIP as a release asset.
 - Sync runs only when destination is configured and sync is enabled.
 
 ### 3. Validate outputs
 
 ZIP validation checklist:
 
+- Download package is a single installable ZIP.
 - Archive has one top-level theme folder.
 - Contents match [src](src) payload.
 - No repository-level development files are included.
@@ -211,10 +214,14 @@ Repo sync excludes `vendor/` by design.
 	- Check `THEME_SLUG` and manual `theme_slug` input.
 	- For release runs, confirm release tag value.
 
-4. Local breakpoints not hitting in theme files
+4. Downloaded ZIP appears to contain another ZIP
+	- Confirm you downloaded the installable package from the release assets list.
+	- For manual runs, verify the artifact is configured as a single-file artifact and download the generated ZIP file directly.
+
+5. Local breakpoints not hitting in theme files
 	- Re-check theme path alignment in [docker-compose.yml](.devcontainer/docker-compose.yml) and [launch.json](.vscode/launch.json).
 
-5. WordPress asks for FTP credentials when installing plugin/theme ZIPs
+6. WordPress asks for FTP credentials when installing plugin/theme ZIPs
 	- Confirm `.devcontainer/setup.sh` completed successfully after container startup.
 	- Verify `wp-content/themes` and `wp-content/plugins` are writable in the container and use expected ownership/modes.
 	- Confirm `.devcontainer/docker-compose.yml` sets `WORDPRESS_CONFIG_EXTRA` with `FS_METHOD` set to `direct`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in this project, please report it responsibly using [GitHub's private vulnerability reporting](https://github.com/markheydon/avada-child-theme-src/security/advisories/new) rather than opening a public issue.
+If you discover a security vulnerability in this project, please report it responsibly using [GitHub's private vulnerability reporting](https://github.com/markheydon/avada-child-theme-dev/security/advisories/new) rather than opening a public issue.
 
 This allows the details to remain private until a fix is in place.
 


### PR DESCRIPTION
Addressed issues with nested zip files in theme downloads and updated the repository naming convention to require a `-dev` suffix.